### PR TITLE
r.lake.series: Improve frange function

### DIFF
--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -132,9 +132,14 @@ def format_order(number, zeros):
 
 
 def frange(x, y, step):
-    while x <= y:
-        yield x
-        x += step
+    return [
+        val / 1000 
+        for val in range(
+            int(x * 1000), 
+            int((y + step) * 1000), 
+            int(step * 1000)
+        )
+    ]
 
 
 def check_maps_exist(maps, mapset):

--- a/src/raster/r.lake.series/r.lake.series.py
+++ b/src/raster/r.lake.series/r.lake.series.py
@@ -191,9 +191,7 @@ def main():
     title = _("r.lake series")
     desctiption = _("r.lake series")
 
-    water_levels = [
-        step for step in frange(start_water_level, end_water_level, water_level_step)
-    ]
+    water_levels = frange(start_water_level, end_water_level, water_level_step)
     outputs = ["%s%s%s" % (basename, "_", water_level) for water_level in water_levels]
 
     if not gcore.overwrite():


### PR DESCRIPTION
The previous version of the frange function would return bad arrays for steps <0.25. For example:
```
>>> [step for step in frange(2.0, 3.0, 0.1)]
[2.0, 2.1, 2.2, 2.3000000000000003, 2.4000000000000004, 2.5000000000000004, 2.6000000000000005, 2.7000000000000006, 2.8000000000000007, 2.900000000000001]
```

This new version will work for steps with up to 3 decimal places.